### PR TITLE
Beanstalk Build and Init Fix

### DIFF
--- a/adm/sysv/beanstalkd.init
+++ b/adm/sysv/beanstalkd.init
@@ -61,7 +61,7 @@ start() {
         fi
     fi
 
-    $exec $options &
+    $exec $options >/dev/null 2>&1 &
     retval=$?
     if [ $retval -eq 0 ]; then
         touch $lockfile

--- a/pkg/beanstalkd.spec.in
+++ b/pkg/beanstalkd.spec.in
@@ -39,7 +39,7 @@ make %{?_smp_mflags}
 
 %install
 rm -rf $RPM_BUILD_ROOT
-make install PREFIX=$RPM_BUILD_ROOT%{_prefix} DESTDIR=$RPM_BUILD_ROOT
+make install PREFIX=%{_prefix} DESTDIR=$RPM_BUILD_ROOT
 %{__install} -p -D -m 0644 doc/%{name}.1 %{buildroot}%{_mandir}/man1/%{name}.1
 %{__install} -p -D -m 0755 adm/sysv/%{name}.init %{buildroot}%{_initrddir}/%{name}
 %{__install} -p -D -m 0644 adm/sysv/%{name}.sysconfig %{buildroot}%{_sysconfdir}/sysconfig/%{name}

--- a/pkg/beanstalkd.spec.in
+++ b/pkg/beanstalkd.spec.in
@@ -5,7 +5,7 @@
 
 Name:           beanstalkd
 Version:        @VERSION@
-Release:        0%{?dist}
+Release:        %{ci_build_number}
 Summary:        A simple, fast workqueue service
 
 Group:          System Environment/Daemons


### PR DESCRIPTION
### Changes
* Fix build process on jenkins
 * Previously, ```RPM_BUILD_ROOT``` was being prepended to the install prefix, which caused builds to fail on jenkins because files were not in the right place
* Update init script deployed with RPM to redirect output to ```/dev/null```
 * This will prevent the output like ```r 25``` we always see to the console
 * This also closes streams properly so that starting beanstalk can allow a highstate to finish.
* Use CI Build Number as "Release" tag so each rpm is labelled uniquely